### PR TITLE
browserslist 默认配置

### DIFF
--- a/build/test.js
+++ b/build/test.js
@@ -61,9 +61,7 @@ function build() {
   })
 }
 
-fs.emptyDirSync(
-  paths.dist + (config.keyword.UMDCOMPILE == entry ? '' : '/' + entry)
-)
+fs.emptyDirSync(paths.dist + '/' + entry)
 
 build()
   .then(output => {

--- a/config/default.js
+++ b/config/default.js
@@ -20,26 +20,9 @@ module.exports = {
   esm: ['@mfelibs'],
   // 打包 dll
   vendor: [],
-  paths: {},
-  build: {
-    env: {},
-    assetsPublicPath: '',
-    productionGzipExtensions: ['js', 'css'],
-    // Run the build command with an extra argument to
-    // View the bundle analyzer report after build finishes:
-    // `npm run build --report`
-    // Set to `true` or `false` to always turn it on or off
-    bundleAnalyzerReport: process.env.npm_config_report,
-    // upload bundle use ftp
-    // `npm run build <page> --ftp [namespace]`
-    // Set to `true` or `false` to always turn it on or off
-    uploadFtp: process.env.npm_config_ftp
-  },
+  build: {},
   dev: {
-    env: {},
     port: 3022,
-    assetsPublicPath: '',
-    proxyTable: {},
     // CSS Sourcemaps off by default because relative paths are "buggy"
     // with this option, according to the CSS-Loader README
     // (https://github.com/webpack/css-loader#sourcemaps)
@@ -60,14 +43,18 @@ module.exports = {
   },
   // hybrid 项目配置，存在此属性时，将会生成 zip 包
   hybrid: {},
-  browserslist: {
-    browsers: [
-      '> 1%',
-      'last 4 versions',
-      'ios >= 8',
-      'android >= 4.1',
-      'not ie < 9'
-    ],
-    flexbox: 'no-2009'
+  browserslist: [
+    '> 1%',
+    'last 4 versions',
+    'ios >= 8',
+    'android >= 4.1',
+    'not ie < 9'
+  ],
+  postcss: {
+    flexbox: 'no-2009',
+    features: {
+      // 与雪碧图使用时存在 bug，在此禁用
+      imageSet: false
+    }
   }
 }

--- a/config/default.js
+++ b/config/default.js
@@ -52,9 +52,10 @@ module.exports = {
   ],
   postcss: {
     flexbox: 'no-2009',
+    // https://github.com/jonathantneal/postcss-preset-env/blob/master/lib/plugins-by-specification-id.js
     features: {
-      // 与雪碧图使用时存在 bug，在此禁用
-      imageSet: false
+      // image-set polyfill 与雪碧图使用时存在 bug，在此禁用
+      'css-images-image-set-notation': false
     }
   }
 }

--- a/config/env.js
+++ b/config/env.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs')
 const paths = require('./paths')
+const defConf = require('./default')
 const maraConf = require(paths.marauder)
 
 const NODE_ENV = process.env.NODE_ENV
@@ -9,6 +10,15 @@ if (!NODE_ENV) {
   throw new Error(
     'The NODE_ENV environment variable is required but was not specified.'
   )
+}
+
+const browserslist = require('browserslist')
+
+// https://github.com/ai/browserslist/blob/master/node.js
+if (!browserslist.findConfig(paths.app)) {
+  // 默认浏览器配置，移动为先
+  // babel-preset-env，Autoprefixer 使用
+  process.env.BROWSERSLIST = defConf.browserslist
 }
 
 // 自定义环境变量前缀

--- a/config/index.js
+++ b/config/index.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const browserslist = require('browserslist')
 const paths = require('./paths')
 const getEnv = require('./env')
 const { ensureSlash, camelName } = require('../libs/utils')
+const defConf = require('./default')
 const maraConf = require(paths.marauder)
 const pkgName = require(paths.packageJson).name
 
@@ -28,25 +28,20 @@ module.exports = {
     amd: pkgName,
     commonjs: pkgName
   },
-  keyword: {
-    // 组件 entry 关键字，用于作为 umd 组件传递进来的参数
-    UMDCOMPILE: 'UMDCOMPILE'
-  },
   // 压缩配置
   compress: {
     // 移除 console
     drop_console: false
   },
-  entry: 'src/view/*/index.js',
+  entry: defConf.esm.entry,
   // 通知 babel 编译 node_module 里额外的模块
-  esm: ['@mfelibs'],
+  esm: defConf.esm,
   // 打包 dll
   vendor: [],
   paths: paths,
   build: {
     env: getEnv(publicPath.slice(0, -1)),
     assetsPublicPath: publicPath,
-    productionGzipExtensions: ['js', 'css'],
     // Run the build command with an extra argument to
     // View the bundle analyzer report after build finishes:
     // `npm run build --report`
@@ -59,7 +54,7 @@ module.exports = {
   },
   dev: {
     env: getEnv(publicDevPath.slice(0, -1)),
-    port: 3022,
+    port: defConf.dev.port,
     assetsPublicPath: publicDevPath,
     proxyTable: {},
     // CSS Sourcemaps off by default because relative paths are "buggy"
@@ -69,34 +64,8 @@ module.exports = {
     // just be aware of this issue when enabling this option.
     cssSourceMap: false
   },
-  ftp: Object.assign(
-    {
-      host: '', // 主机
-      port: 0,
-      user: '',
-      password: '',
-      reload: true, // 刷新缓存
-      openBrowser: true, // 上传完毕后自动打开浏览器
-      remotePath: {
-        version: true // 添加 version 路径
-      }
-    },
-    maraConf.ftp
-  ),
+  ftp: Object.assign({}, defConf.ftp, maraConf.ftp),
   // hybrid 项目配置，存在此属性时，将会生成 zip 包
-  hybrid: {},
-  postcss: {
-    // browsers: [
-    //   '> 1%',
-    //   'last 4 versions',
-    //   'ios >= 8',
-    //   'android >= 4.1',
-    //   'not ie < 9'
-    // ],
-    flexbox: 'no-2009',
-    features: {
-      // 与雪碧图使用时存在 bug，在此禁用
-      imageSet: false
-    }
-  }
+  hybrid: defConf.hybrid,
+  postcss: defConf.postcss
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2648,6 +2648,14 @@
                 "postcss-selector-matches": "3.0.1"
             }
         },
+        "postcss-flexbugs-fixes": {
+            "version": "3.3.0",
+            "resolved": "http://registry.npm.taobao.org/postcss-flexbugs-fixes/download/postcss-flexbugs-fixes-3.3.0.tgz",
+            "integrity": "sha1-4AhJtTYGN0naUKDUELpdnuZeJ7g=",
+            "requires": {
+                "postcss": "6.0.16"
+            }
+        },
         "postcss-font-family-system-ui": {
             "version": "3.0.0",
             "resolved": "http://registry.npm.taobao.org/postcss-font-family-system-ui/download/postcss-font-family-system-ui-3.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,57 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "acorn": {
+            "version": "5.3.0",
+            "resolved": "http://registry.npm.taobao.org/acorn/download/acorn-5.3.0.tgz",
+            "integrity": "sha1-dEbTlFnFT7SagObuZHgUm5QOyCI="
+        },
+        "acorn-dynamic-import": {
+            "version": "2.0.2",
+            "resolved": "http://registry.npm.taobao.org/acorn-dynamic-import/download/acorn-dynamic-import-2.0.2.tgz",
+            "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+            "requires": {
+                "acorn": "4.0.13"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "4.0.13",
+                    "resolved": "http://registry.npm.taobao.org/acorn/download/acorn-4.0.13.tgz",
+                    "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+                }
+            }
+        },
+        "ajv": {
+            "version": "5.5.2",
+            "resolved": "http://registry.npm.taobao.org/ajv/download/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+            }
+        },
+        "ajv-keywords": {
+            "version": "2.1.1",
+            "resolved": "http://registry.npm.taobao.org/ajv-keywords/download/ajv-keywords-2.1.1.tgz",
+            "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
+        },
+        "align-text": {
+            "version": "0.1.4",
+            "resolved": "http://registry.npm.taobao.org/align-text/download/align-text-0.1.4.tgz",
+            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "requires": {
+                "kind-of": "3.2.2",
+                "longest": "1.0.1",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
         "ansi-styles": {
             "version": "3.2.0",
             "resolved": "http://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.0.tgz",
@@ -12,10 +63,183 @@
                 "color-convert": "1.9.1"
             }
         },
+        "anymatch": {
+            "version": "1.3.2",
+            "resolved": "http://registry.npm.taobao.org/anymatch/download/anymatch-1.3.2.tgz",
+            "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+            "requires": {
+                "micromatch": "2.3.11",
+                "normalize-path": "2.1.1"
+            }
+        },
+        "arr-diff": {
+            "version": "2.0.0",
+            "resolved": "http://registry.npm.taobao.org/arr-diff/download/arr-diff-2.0.0.tgz",
+            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "requires": {
+                "arr-flatten": "1.1.0"
+            }
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npm.taobao.org/arr-flatten/download/arr-flatten-1.1.0.tgz",
+            "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+        },
+        "array-unique": {
+            "version": "0.2.1",
+            "resolved": "http://registry.npm.taobao.org/array-unique/download/array-unique-0.2.1.tgz",
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+        },
+        "asn1.js": {
+            "version": "4.9.2",
+            "resolved": "http://registry.npm.taobao.org/asn1.js/download/asn1.js-4.9.2.tgz",
+            "integrity": "sha1-gRfvT37YfNj4kES1v/l6wkOhbJo=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
+        },
+        "assert": {
+            "version": "1.4.1",
+            "resolved": "http://registry.npm.taobao.org/assert/download/assert-1.4.1.tgz",
+            "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+            "requires": {
+                "util": "0.10.3"
+            }
+        },
+        "async": {
+            "version": "2.6.0",
+            "resolved": "http://registry.npm.taobao.org/async/download/async-2.6.0.tgz",
+            "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
+            "requires": {
+                "lodash": "4.17.4"
+            }
+        },
+        "async-each": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npm.taobao.org/async-each/download/async-each-1.0.1.tgz",
+            "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+        },
         "balanced-match": {
             "version": "0.4.2",
             "resolved": "http://registry.npm.taobao.org/balanced-match/download/balanced-match-0.4.2.tgz",
             "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        },
+        "base64-js": {
+            "version": "1.2.1",
+            "resolved": "http://registry.npm.taobao.org/base64-js/download/base64-js-1.2.1.tgz",
+            "integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY="
+        },
+        "big.js": {
+            "version": "3.2.0",
+            "resolved": "http://registry.npm.taobao.org/big.js/download/big.js-3.2.0.tgz",
+            "integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4="
+        },
+        "binary-extensions": {
+            "version": "1.11.0",
+            "resolved": "http://registry.npm.taobao.org/binary-extensions/download/binary-extensions-1.11.0.tgz",
+            "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+        },
+        "bn.js": {
+            "version": "4.11.8",
+            "resolved": "http://registry.npm.taobao.org/bn.js/download/bn.js-4.11.8.tgz",
+            "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8="
+        },
+        "brace-expansion": {
+            "version": "1.1.8",
+            "resolved": "http://registry.npm.taobao.org/brace-expansion/download/brace-expansion-1.1.8.tgz",
+            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+            },
+            "dependencies": {
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "http://registry.npm.taobao.org/balanced-match/download/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                }
+            }
+        },
+        "braces": {
+            "version": "1.8.5",
+            "resolved": "http://registry.npm.taobao.org/braces/download/braces-1.8.5.tgz",
+            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+            }
+        },
+        "brorand": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npm.taobao.org/brorand/download/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+        },
+        "browserify-aes": {
+            "version": "1.1.1",
+            "resolved": "http://registry.npm.taobao.org/browserify-aes/download/browserify-aes-1.1.1.tgz",
+            "integrity": "sha1-OLerVe24Bv8tzaGn8WIHc6R3xJ8=",
+            "requires": {
+                "buffer-xor": "1.0.3",
+                "cipher-base": "1.0.4",
+                "create-hash": "1.1.3",
+                "evp_bytestokey": "1.0.3",
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "browserify-cipher": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/browserify-cipher/download/browserify-cipher-1.0.0.tgz",
+            "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+            "requires": {
+                "browserify-aes": "1.1.1",
+                "browserify-des": "1.0.0",
+                "evp_bytestokey": "1.0.3"
+            }
+        },
+        "browserify-des": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/browserify-des/download/browserify-des-1.0.0.tgz",
+            "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+            "requires": {
+                "cipher-base": "1.0.4",
+                "des.js": "1.0.0",
+                "inherits": "2.0.3"
+            }
+        },
+        "browserify-rsa": {
+            "version": "4.0.1",
+            "resolved": "http://registry.npm.taobao.org/browserify-rsa/download/browserify-rsa-4.0.1.tgz",
+            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "randombytes": "2.0.6"
+            }
+        },
+        "browserify-sign": {
+            "version": "4.0.4",
+            "resolved": "http://registry.npm.taobao.org/browserify-sign/download/browserify-sign-4.0.4.tgz",
+            "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "elliptic": "6.4.0",
+                "inherits": "2.0.3",
+                "parse-asn1": "5.1.0"
+            }
+        },
+        "browserify-zlib": {
+            "version": "0.2.0",
+            "resolved": "http://registry.npm.taobao.org/browserify-zlib/download/browserify-zlib-0.2.0.tgz",
+            "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+            "requires": {
+                "pako": "1.0.6"
+            }
         },
         "browserslist": {
             "version": "2.11.3",
@@ -25,6 +249,36 @@
                 "caniuse-lite": "1.0.30000792",
                 "electron-to-chromium": "1.3.31"
             }
+        },
+        "buffer": {
+            "version": "4.9.1",
+            "resolved": "http://registry.npm.taobao.org/buffer/download/buffer-4.9.1.tgz",
+            "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+            "requires": {
+                "base64-js": "1.2.1",
+                "ieee754": "1.1.8",
+                "isarray": "1.0.0"
+            }
+        },
+        "buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "http://registry.npm.taobao.org/buffer-xor/download/buffer-xor-1.0.3.tgz",
+            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+        },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "http://registry.npm.taobao.org/builtin-modules/download/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+        },
+        "builtin-status-codes": {
+            "version": "3.0.0",
+            "resolved": "http://registry.npm.taobao.org/builtin-status-codes/download/builtin-status-codes-3.0.0.tgz",
+            "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+        },
+        "camelcase": {
+            "version": "1.2.1",
+            "resolved": "http://registry.npm.taobao.org/camelcase/download/camelcase-1.2.1.tgz",
+            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
         },
         "caniuse-api": {
             "version": "2.0.0",
@@ -42,10 +296,64 @@
             "resolved": "http://registry.npm.taobao.org/caniuse-lite/download/caniuse-lite-1.0.30000792.tgz",
             "integrity": "sha1-0M6pgfgRjzlhRxr7tDyaHlu/AzI="
         },
+        "center-align": {
+            "version": "0.1.3",
+            "resolved": "http://registry.npm.taobao.org/center-align/download/center-align-0.1.3.tgz",
+            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "requires": {
+                "align-text": "0.1.4",
+                "lazy-cache": "1.0.4"
+            }
+        },
+        "chokidar": {
+            "version": "1.7.0",
+            "resolved": "http://registry.npm.taobao.org/chokidar/download/chokidar-1.7.0.tgz",
+            "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+            "requires": {
+                "anymatch": "1.3.2",
+                "async-each": "1.0.1",
+                "fsevents": "1.1.3",
+                "glob-parent": "2.0.0",
+                "inherits": "2.0.3",
+                "is-binary-path": "1.0.1",
+                "is-glob": "2.0.1",
+                "path-is-absolute": "1.0.1",
+                "readdirp": "2.1.0"
+            }
+        },
+        "cipher-base": {
+            "version": "1.0.4",
+            "resolved": "http://registry.npm.taobao.org/cipher-base/download/cipher-base-1.0.4.tgz",
+            "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+            "requires": {
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "cliui": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npm.taobao.org/cliui/download/cliui-2.1.0.tgz",
+            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+            "requires": {
+                "center-align": "0.1.3",
+                "right-align": "0.1.3",
+                "wordwrap": "0.0.2"
+            }
+        },
         "clone": {
             "version": "1.0.3",
             "resolved": "http://registry.npm.taobao.org/clone/download/clone-1.0.3.tgz",
             "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "http://registry.npm.taobao.org/co/download/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npm.taobao.org/code-point-at/download/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "color": {
             "version": "0.11.4",
@@ -78,10 +386,94 @@
                 "color-name": "1.1.3"
             }
         },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "http://registry.npm.taobao.org/concat-map/download/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "console-browserify": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npm.taobao.org/console-browserify/download/console-browserify-1.1.0.tgz",
+            "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+            "requires": {
+                "date-now": "0.1.4"
+            }
+        },
+        "constants-browserify": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/constants-browserify/download/constants-browserify-1.0.0.tgz",
+            "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+        },
         "core-js": {
             "version": "2.5.3",
             "resolved": "http://registry.npm.taobao.org/core-js/download/core-js-2.5.3.tgz",
             "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "http://registry.npm.taobao.org/core-util-is/download/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "create-ecdh": {
+            "version": "4.0.0",
+            "resolved": "http://registry.npm.taobao.org/create-ecdh/download/create-ecdh-4.0.0.tgz",
+            "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0"
+            }
+        },
+        "create-hash": {
+            "version": "1.1.3",
+            "resolved": "http://registry.npm.taobao.org/create-hash/download/create-hash-1.1.3.tgz",
+            "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+            "requires": {
+                "cipher-base": "1.0.4",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.1",
+                "sha.js": "2.4.10"
+            }
+        },
+        "create-hmac": {
+            "version": "1.1.6",
+            "resolved": "http://registry.npm.taobao.org/create-hmac/download/create-hmac-1.1.6.tgz",
+            "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+            "requires": {
+                "cipher-base": "1.0.4",
+                "create-hash": "1.1.3",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.1",
+                "safe-buffer": "5.1.1",
+                "sha.js": "2.4.10"
+            }
+        },
+        "cross-spawn": {
+            "version": "5.1.0",
+            "resolved": "http://registry.npm.taobao.org/cross-spawn/download/cross-spawn-5.1.0.tgz",
+            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "requires": {
+                "lru-cache": "4.1.1",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+            }
+        },
+        "crypto-browserify": {
+            "version": "3.12.0",
+            "resolved": "http://registry.npm.taobao.org/crypto-browserify/download/crypto-browserify-3.12.0.tgz",
+            "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
+            "requires": {
+                "browserify-cipher": "1.0.0",
+                "browserify-sign": "4.0.4",
+                "create-ecdh": "4.0.0",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "diffie-hellman": "5.0.2",
+                "inherits": "2.0.3",
+                "pbkdf2": "3.0.14",
+                "public-encrypt": "4.0.0",
+                "randombytes": "2.0.6",
+                "randomfill": "1.0.3"
+            }
         },
         "css-color-function": {
             "version": "1.3.3",
@@ -106,6 +498,19 @@
             "resolved": "http://registry.npm.taobao.org/css-unit-converter/download/css-unit-converter-1.1.1.tgz",
             "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY="
         },
+        "d": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/d/download/d-1.0.0.tgz",
+            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+            "requires": {
+                "es5-ext": "0.10.38"
+            }
+        },
+        "date-now": {
+            "version": "0.1.4",
+            "resolved": "http://registry.npm.taobao.org/date-now/download/date-now-0.1.4.tgz",
+            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs="
+        },
         "debug": {
             "version": "3.1.0",
             "resolved": "http://registry.npm.taobao.org/debug/download/debug-3.1.0.tgz",
@@ -114,40 +519,1404 @@
                 "ms": "2.0.0"
             }
         },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "http://registry.npm.taobao.org/decamelize/download/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+        },
+        "des.js": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/des.js/download/des.js-1.0.0.tgz",
+            "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+            "requires": {
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
+        },
+        "diffie-hellman": {
+            "version": "5.0.2",
+            "resolved": "http://registry.npm.taobao.org/diffie-hellman/download/diffie-hellman-5.0.2.tgz",
+            "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "miller-rabin": "4.0.1",
+                "randombytes": "2.0.6"
+            }
+        },
+        "domain-browser": {
+            "version": "1.2.0",
+            "resolved": "http://registry.npm.taobao.org/domain-browser/download/domain-browser-1.2.0.tgz",
+            "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto="
+        },
+        "dotenv": {
+            "version": "4.0.0",
+            "resolved": "http://registry.npm.taobao.org/dotenv/download/dotenv-4.0.0.tgz",
+            "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+        },
+        "dotenv-expand": {
+            "version": "4.0.1",
+            "resolved": "http://registry.npm.taobao.org/dotenv-expand/download/dotenv-expand-4.0.1.tgz",
+            "integrity": "sha1-aP3cFWGBTgoQlkERBX/xOM7X16g="
+        },
         "electron-to-chromium": {
             "version": "1.3.31",
             "resolved": "http://registry.npm.taobao.org/electron-to-chromium/download/electron-to-chromium-1.3.31.tgz",
             "integrity": "sha1-ANgyy6n+I1hlKwxIqIFsjjoDfp8="
+        },
+        "elliptic": {
+            "version": "6.4.0",
+            "resolved": "http://registry.npm.taobao.org/elliptic/download/elliptic-6.4.0.tgz",
+            "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.3",
+                "hmac-drbg": "1.0.1",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0",
+                "minimalistic-crypto-utils": "1.0.1"
+            }
+        },
+        "emojis-list": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npm.taobao.org/emojis-list/download/emojis-list-2.1.0.tgz",
+            "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+        },
+        "enhanced-resolve": {
+            "version": "3.4.1",
+            "resolved": "http://registry.npm.taobao.org/enhanced-resolve/download/enhanced-resolve-3.4.1.tgz",
+            "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "memory-fs": "0.4.1",
+                "object-assign": "4.1.1",
+                "tapable": "0.2.8"
+            },
+            "dependencies": {
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "http://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+                }
+            }
+        },
+        "errno": {
+            "version": "0.1.6",
+            "resolved": "http://registry.npm.taobao.org/errno/download/errno-0.1.6.tgz",
+            "integrity": "sha1-w4bOimKD8U/AlWO3FWCQjJv1MCY=",
+            "requires": {
+                "prr": "1.0.1"
+            }
+        },
+        "error-ex": {
+            "version": "1.3.1",
+            "resolved": "http://registry.npm.taobao.org/error-ex/download/error-ex-1.3.1.tgz",
+            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+            "requires": {
+                "is-arrayish": "0.2.1"
+            },
+            "dependencies": {
+                "is-arrayish": {
+                    "version": "0.2.1",
+                    "resolved": "http://registry.npm.taobao.org/is-arrayish/download/is-arrayish-0.2.1.tgz",
+                    "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+                }
+            }
+        },
+        "es5-ext": {
+            "version": "0.10.38",
+            "resolved": "http://registry.npm.taobao.org/es5-ext/download/es5-ext-0.10.38.tgz",
+            "integrity": "sha1-+n1A1lu8m7imfh0/nMZWoAUw7tM=",
+            "requires": {
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
+            }
+        },
+        "es6-iterator": {
+            "version": "2.0.3",
+            "resolved": "http://registry.npm.taobao.org/es6-iterator/download/es6-iterator-2.0.3.tgz",
+            "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38",
+                "es6-symbol": "3.1.1"
+            }
+        },
+        "es6-map": {
+            "version": "0.1.5",
+            "resolved": "http://registry.npm.taobao.org/es6-map/download/es6-map-0.1.5.tgz",
+            "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38",
+                "es6-iterator": "2.0.3",
+                "es6-set": "0.1.5",
+                "es6-symbol": "3.1.1",
+                "event-emitter": "0.3.5"
+            }
+        },
+        "es6-set": {
+            "version": "0.1.5",
+            "resolved": "http://registry.npm.taobao.org/es6-set/download/es6-set-0.1.5.tgz",
+            "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38",
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1",
+                "event-emitter": "0.3.5"
+            }
+        },
+        "es6-symbol": {
+            "version": "3.1.1",
+            "resolved": "http://registry.npm.taobao.org/es6-symbol/download/es6-symbol-3.1.1.tgz",
+            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38"
+            }
+        },
+        "es6-weak-map": {
+            "version": "2.0.2",
+            "resolved": "http://registry.npm.taobao.org/es6-weak-map/download/es6-weak-map-2.0.2.tgz",
+            "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38",
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
+            }
         },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "http://registry.npm.taobao.org/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
+        "escope": {
+            "version": "3.6.0",
+            "resolved": "http://registry.npm.taobao.org/escope/download/escope-3.6.0.tgz",
+            "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+            "requires": {
+                "es6-map": "0.1.5",
+                "es6-weak-map": "2.0.2",
+                "esrecurse": "4.2.0",
+                "estraverse": "4.2.0"
+            }
+        },
+        "esrecurse": {
+            "version": "4.2.0",
+            "resolved": "http://registry.npm.taobao.org/esrecurse/download/esrecurse-4.2.0.tgz",
+            "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+            "requires": {
+                "estraverse": "4.2.0",
+                "object-assign": "4.1.1"
+            },
+            "dependencies": {
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "http://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+                }
+            }
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "http://registry.npm.taobao.org/estraverse/download/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+        },
+        "event-emitter": {
+            "version": "0.3.5",
+            "resolved": "http://registry.npm.taobao.org/event-emitter/download/event-emitter-0.3.5.tgz",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+            "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.38"
+            }
+        },
+        "events": {
+            "version": "1.1.1",
+            "resolved": "http://registry.npm.taobao.org/events/download/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "evp_bytestokey": {
+            "version": "1.0.3",
+            "resolved": "http://registry.npm.taobao.org/evp_bytestokey/download/evp_bytestokey-1.0.3.tgz",
+            "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+            "requires": {
+                "md5.js": "1.3.4",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "execa": {
+            "version": "0.7.0",
+            "resolved": "http://registry.npm.taobao.org/execa/download/execa-0.7.0.tgz",
+            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+            "requires": {
+                "cross-spawn": "5.1.0",
+                "get-stream": "3.0.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
+            }
+        },
+        "expand-brackets": {
+            "version": "0.1.5",
+            "resolved": "http://registry.npm.taobao.org/expand-brackets/download/expand-brackets-0.1.5.tgz",
+            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "requires": {
+                "is-posix-bracket": "0.1.1"
+            }
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "http://registry.npm.taobao.org/expand-range/download/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "requires": {
+                "fill-range": "2.2.3"
+            }
+        },
+        "extglob": {
+            "version": "0.3.2",
+            "resolved": "http://registry.npm.taobao.org/extglob/download/extglob-0.3.2.tgz",
+            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "requires": {
+                "is-extglob": "1.0.0"
+            }
+        },
+        "fast-deep-equal": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/fast-deep-equal/download/fast-deep-equal-1.0.0.tgz",
+            "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "http://registry.npm.taobao.org/fast-json-stable-stringify/download/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+        },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "http://registry.npm.taobao.org/filename-regex/download/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+        },
+        "fill-range": {
+            "version": "2.2.3",
+            "resolved": "http://registry.npm.taobao.org/fill-range/download/fill-range-2.2.3.tgz",
+            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+            "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.7",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "find-up": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npm.taobao.org/find-up/download/find-up-2.1.0.tgz",
+            "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+            "requires": {
+                "locate-path": "2.0.0"
+            }
+        },
         "flatten": {
             "version": "1.0.2",
             "resolved": "http://registry.npm.taobao.org/flatten/download/flatten-1.0.2.tgz",
             "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "http://registry.npm.taobao.org/for-in/download/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "http://registry.npm.taobao.org/for-own/download/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "requires": {
+                "for-in": "1.0.2"
+            }
+        },
+        "fsevents": {
+            "version": "1.1.3",
+            "resolved": "http://registry.npm.taobao.org/fsevents/download/fsevents-1.1.3.tgz",
+            "integrity": "sha1-EfgjGPX+e7LNIpZaEI6TBiCCFtg=",
+            "optional": true,
+            "requires": {
+                "nan": "2.8.0",
+                "node-pre-gyp": "0.6.39"
+            },
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "ajv": {
+                    "version": "4.11.8",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true
+                },
+                "aproba": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.2.9"
+                    }
+                },
+                "asn1": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "optional": true
+                },
+                "assert-plus": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "aws-sign2": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "aws4": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "balanced-match": {
+                    "version": "0.4.2",
+                    "bundled": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "tweetnacl": "0.14.5"
+                    }
+                },
+                "block-stream": {
+                    "version": "0.0.9",
+                    "bundled": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "boom": {
+                    "version": "2.10.1",
+                    "bundled": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.7",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "buffer-shims": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "combined-stream": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "requires": {
+                        "delayed-stream": "1.0.0"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "cryptiles": {
+                    "version": "2.0.5",
+                    "bundled": true,
+                    "requires": {
+                        "boom": "2.10.1"
+                    }
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.8",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "deep-extend": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "detect-libc": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "extend": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "extsprintf": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "form-data": {
+                    "version": "2.1.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.15"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "fstream": {
+                    "version": "1.0.11",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.1"
+                    }
+                },
+                "fstream-ignore": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4"
+                    }
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "aproba": "1.1.1",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                    }
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true
+                },
+                "har-schema": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "optional": true
+                },
+                "har-validator": {
+                    "version": "4.2.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                    }
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "hawk": {
+                    "version": "3.1.3",
+                    "bundled": true,
+                    "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                    }
+                },
+                "hoek": {
+                    "version": "2.16.3",
+                    "bundled": true
+                },
+                "http-signature": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.0",
+                        "sshpk": "1.13.0"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true
+                },
+                "ini": {
+                    "version": "1.3.4",
+                    "bundled": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "jodid25519": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "jsbn": "0.1.1"
+                    }
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "optional": true
+                },
+                "json-stable-stringify": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "jsonify": "0.0.0"
+                    }
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "jsonify": {
+                    "version": "0.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "jsprim": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "mime-db": {
+                    "version": "1.27.0",
+                    "bundled": true
+                },
+                "mime-types": {
+                    "version": "2.1.15",
+                    "bundled": true,
+                    "requires": {
+                        "mime-db": "1.27.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "brace-expansion": "1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "node-pre-gyp": {
+                    "version": "0.6.39",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "1.0.2",
+                        "hawk": "3.1.3",
+                        "mkdirp": "0.5.1",
+                        "nopt": "4.0.1",
+                        "npmlog": "4.1.0",
+                        "rc": "1.2.1",
+                        "request": "2.81.0",
+                        "rimraf": "2.6.1",
+                        "semver": "5.3.0",
+                        "tar": "2.2.1",
+                        "tar-pack": "3.4.0"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "abbrev": "1.1.0",
+                        "osenv": "0.1.4"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
+                "performance-now": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "bundled": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "qs": {
+                    "version": "6.4.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "deep-extend": "0.4.2",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.2.9",
+                    "bundled": true,
+                    "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "1.0.1",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "request": {
+                    "version": "2.81.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "4.2.1",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.15",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "0.2.0",
+                        "qs": "6.4.0",
+                        "safe-buffer": "5.0.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.0.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.1",
+                    "bundled": true,
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.0.1",
+                    "bundled": true
+                },
+                "semver": {
+                    "version": "5.3.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "optional": true
+                },
+                "sntp": {
+                    "version": "1.0.9",
+                    "bundled": true,
+                    "requires": {
+                        "hoek": "2.16.3"
+                    }
+                },
+                "sshpk": {
+                    "version": "1.13.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                    },
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "stringstream": {
+                    "version": "0.0.5",
+                    "bundled": true,
+                    "optional": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "requires": {
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
+                    }
+                },
+                "tar-pack": {
+                    "version": "3.4.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "debug": "2.6.8",
+                        "fstream": "1.0.11",
+                        "fstream-ignore": "1.0.5",
+                        "once": "1.4.0",
+                        "readable-stream": "2.2.9",
+                        "rimraf": "2.6.1",
+                        "tar": "2.2.1",
+                        "uid-number": "0.0.6"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "punycode": "1.4.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
+                    }
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "bundled": true,
+                    "optional": true
+                },
+                "uid-number": {
+                    "version": "0.0.6",
+                    "bundled": true,
+                    "optional": true
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "uuid": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "optional": true
+                },
+                "verror": {
+                    "version": "1.3.6",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "extsprintf": "1.0.2"
+                    }
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "optional": true,
+                    "requires": {
+                        "string-width": "1.0.2"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true
+                }
+            }
+        },
+        "get-caller-file": {
+            "version": "1.0.2",
+            "resolved": "http://registry.npm.taobao.org/get-caller-file/download/get-caller-file-1.0.2.tgz",
+            "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+        },
+        "get-stream": {
+            "version": "3.0.0",
+            "resolved": "http://registry.npm.taobao.org/get-stream/download/get-stream-3.0.0.tgz",
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "http://registry.npm.taobao.org/glob-base/download/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+            }
+        },
+        "glob-parent": {
+            "version": "2.0.0",
+            "resolved": "http://registry.npm.taobao.org/glob-parent/download/glob-parent-2.0.0.tgz",
+            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "requires": {
+                "is-glob": "2.0.1"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "http://registry.npm.taobao.org/graceful-fs/download/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "has-flag": {
             "version": "2.0.0",
             "resolved": "http://registry.npm.taobao.org/has-flag/download/has-flag-2.0.0.tgz",
             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
         },
+        "hash-base": {
+            "version": "2.0.2",
+            "resolved": "http://registry.npm.taobao.org/hash-base/download/hash-base-2.0.2.tgz",
+            "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+            "requires": {
+                "inherits": "2.0.3"
+            }
+        },
+        "hash.js": {
+            "version": "1.1.3",
+            "resolved": "http://registry.npm.taobao.org/hash.js/download/hash.js-1.1.3.tgz",
+            "integrity": "sha1-NA3tvmKQGHFRweodd3o0SJNd+EY=",
+            "requires": {
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
+        },
+        "hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npm.taobao.org/hmac-drbg/download/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "requires": {
+                "hash.js": "1.1.3",
+                "minimalistic-assert": "1.0.0",
+                "minimalistic-crypto-utils": "1.0.1"
+            }
+        },
+        "hosted-git-info": {
+            "version": "2.5.0",
+            "resolved": "http://registry.npm.taobao.org/hosted-git-info/download/hosted-git-info-2.5.0.tgz",
+            "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw="
+        },
+        "https-browserify": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/https-browserify/download/https-browserify-1.0.0.tgz",
+            "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+        },
+        "ieee754": {
+            "version": "1.1.8",
+            "resolved": "http://registry.npm.taobao.org/ieee754/download/ieee754-1.1.8.tgz",
+            "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+        },
         "indexes-of": {
             "version": "1.0.1",
             "resolved": "http://registry.npm.taobao.org/indexes-of/download/indexes-of-1.0.1.tgz",
             "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+        },
+        "indexof": {
+            "version": "0.0.1",
+            "resolved": "http://registry.npm.taobao.org/indexof/download/indexof-0.0.1.tgz",
+            "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "http://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "interpret": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npm.taobao.org/interpret/download/interpret-1.1.0.tgz",
+            "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+        },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/invert-kv/download/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
         },
         "is-arrayish": {
             "version": "0.3.1",
             "resolved": "http://registry.npm.taobao.org/is-arrayish/download/is-arrayish-0.3.1.tgz",
             "integrity": "sha1-wt/DhquqDD4zxI2z/ocFnmkGXv0="
         },
+        "is-binary-path": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npm.taobao.org/is-binary-path/download/is-binary-path-1.0.1.tgz",
+            "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+            "requires": {
+                "binary-extensions": "1.11.0"
+            }
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "http://registry.npm.taobao.org/is-buffer/download/is-buffer-1.1.6.tgz",
+            "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+        },
+        "is-builtin-module": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/is-builtin-module/download/is-builtin-module-1.0.0.tgz",
+            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+            "requires": {
+                "builtin-modules": "1.1.1"
+            }
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "http://registry.npm.taobao.org/is-dotfile/download/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "http://registry.npm.taobao.org/is-equal-shallow/download/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "requires": {
+                "is-primitive": "2.0.0"
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "http://registry.npm.taobao.org/is-extendable/download/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+        },
+        "is-extglob": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/is-extglob/download/is-extglob-1.0.0.tgz",
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "requires": {
+                "number-is-nan": "1.0.1"
+            }
+        },
+        "is-glob": {
+            "version": "2.0.1",
+            "resolved": "http://registry.npm.taobao.org/is-glob/download/is-glob-2.0.1.tgz",
+            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "requires": {
+                "is-extglob": "1.0.0"
+            }
+        },
+        "is-number": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npm.taobao.org/is-number/download/is-number-2.1.0.tgz",
+            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "requires": {
+                "kind-of": "3.2.2"
+            }
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "http://registry.npm.taobao.org/is-posix-bracket/download/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "http://registry.npm.taobao.org/is-primitive/download/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npm.taobao.org/is-stream/download/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "http://registry.npm.taobao.org/isexe/download/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        },
         "isnumeric": {
             "version": "0.2.0",
             "resolved": "http://registry.npm.taobao.org/isnumeric/download/isnumeric-0.2.0.tgz",
             "integrity": "sha1-ojR7o2DeGeM9D/1ZD933dVy/LmQ="
+        },
+        "isobject": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npm.taobao.org/isobject/download/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "requires": {
+                "isarray": "1.0.0"
+            }
+        },
+        "json-loader": {
+            "version": "0.5.7",
+            "resolved": "http://registry.npm.taobao.org/json-loader/download/json-loader-0.5.7.tgz",
+            "integrity": "sha1-3KFKcCNf+C8KyaOr62DTN6NlGF0="
+        },
+        "json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "http://registry.npm.taobao.org/json-schema-traverse/download/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+        },
+        "json5": {
+            "version": "0.5.1",
+            "resolved": "http://registry.npm.taobao.org/json5/download/json5-0.5.1.tgz",
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "requires": {
+                "is-buffer": "1.1.6"
+            }
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "http://registry.npm.taobao.org/lazy-cache/download/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+        },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/lcid/download/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "requires": {
+                "invert-kv": "1.0.0"
+            }
+        },
+        "load-json-file": {
+            "version": "2.0.0",
+            "resolved": "http://registry.npm.taobao.org/load-json-file/download/load-json-file-2.0.0.tgz",
+            "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "strip-bom": "3.0.0"
+            }
+        },
+        "loader-runner": {
+            "version": "2.3.0",
+            "resolved": "http://registry.npm.taobao.org/loader-runner/download/loader-runner-2.3.0.tgz",
+            "integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI="
+        },
+        "loader-utils": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npm.taobao.org/loader-utils/download/loader-utils-1.1.0.tgz",
+            "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+            "requires": {
+                "big.js": "3.2.0",
+                "emojis-list": "2.1.0",
+                "json5": "0.5.1"
+            }
+        },
+        "locate-path": {
+            "version": "2.0.0",
+            "resolved": "http://registry.npm.taobao.org/locate-path/download/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "requires": {
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
+            }
+        },
+        "lodash": {
+            "version": "4.17.4",
+            "resolved": "http://registry.npm.taobao.org/lodash/download/lodash-4.17.4.tgz",
+            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         },
         "lodash._reinterpolate": {
             "version": "3.0.0",
@@ -181,35 +1950,345 @@
             "resolved": "http://registry.npm.taobao.org/lodash.uniq/download/lodash.uniq-4.5.0.tgz",
             "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
         },
+        "longest": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npm.taobao.org/longest/download/longest-1.0.1.tgz",
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+        },
+        "lru-cache": {
+            "version": "4.1.1",
+            "resolved": "http://registry.npm.taobao.org/lru-cache/download/lru-cache-4.1.1.tgz",
+            "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+            "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+            }
+        },
         "math-expression-evaluator": {
             "version": "1.2.17",
             "resolved": "http://registry.npm.taobao.org/math-expression-evaluator/download/math-expression-evaluator-1.2.17.tgz",
             "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
+        },
+        "md5.js": {
+            "version": "1.3.4",
+            "resolved": "http://registry.npm.taobao.org/md5.js/download/md5.js-1.3.4.tgz",
+            "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+            "requires": {
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
+            },
+            "dependencies": {
+                "hash-base": {
+                    "version": "3.0.4",
+                    "resolved": "http://registry.npm.taobao.org/hash-base/download/hash-base-3.0.4.tgz",
+                    "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "safe-buffer": "5.1.1"
+                    }
+                }
+            }
+        },
+        "mem": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npm.taobao.org/mem/download/mem-1.1.0.tgz",
+            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "requires": {
+                "mimic-fn": "1.1.0"
+            }
+        },
+        "memory-fs": {
+            "version": "0.4.1",
+            "resolved": "http://registry.npm.taobao.org/memory-fs/download/memory-fs-0.4.1.tgz",
+            "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+            "requires": {
+                "errno": "0.1.6",
+                "readable-stream": "2.3.3"
+            }
+        },
+        "micromatch": {
+            "version": "2.3.11",
+            "resolved": "http://registry.npm.taobao.org/micromatch/download/micromatch-2.3.11.tgz",
+            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
+            }
+        },
+        "miller-rabin": {
+            "version": "4.0.1",
+            "resolved": "http://registry.npm.taobao.org/miller-rabin/download/miller-rabin-4.0.1.tgz",
+            "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npm.taobao.org/mimic-fn/download/mimic-fn-1.1.0.tgz",
+            "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+        },
+        "minimalistic-assert": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/minimalistic-assert/download/minimalistic-assert-1.0.0.tgz",
+            "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M="
+        },
+        "minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npm.taobao.org/minimalistic-crypto-utils/download/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "http://registry.npm.taobao.org/minimatch/download/minimatch-3.0.4.tgz",
+            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+            "requires": {
+                "brace-expansion": "1.1.8"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "http://registry.npm.taobao.org/minimist/download/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "http://registry.npm.taobao.org/mkdirp/download/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "requires": {
+                "minimist": "0.0.8"
+            }
         },
         "ms": {
             "version": "2.0.0",
             "resolved": "http://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
+        "nan": {
+            "version": "2.8.0",
+            "resolved": "http://registry.npm.taobao.org/nan/download/nan-2.8.0.tgz",
+            "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+            "optional": true
+        },
+        "node-libs-browser": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npm.taobao.org/node-libs-browser/download/node-libs-browser-2.1.0.tgz",
+            "integrity": "sha1-X5QmPUBPbkR2fXJpAf/wVHjWAN8=",
+            "requires": {
+                "assert": "1.4.1",
+                "browserify-zlib": "0.2.0",
+                "buffer": "4.9.1",
+                "console-browserify": "1.1.0",
+                "constants-browserify": "1.0.0",
+                "crypto-browserify": "3.12.0",
+                "domain-browser": "1.2.0",
+                "events": "1.1.1",
+                "https-browserify": "1.0.0",
+                "os-browserify": "0.3.0",
+                "path-browserify": "0.0.0",
+                "process": "0.11.10",
+                "punycode": "1.4.1",
+                "querystring-es3": "0.2.1",
+                "readable-stream": "2.3.3",
+                "stream-browserify": "2.0.1",
+                "stream-http": "2.8.0",
+                "string_decoder": "1.0.3",
+                "timers-browserify": "2.0.6",
+                "tty-browserify": "0.0.0",
+                "url": "0.11.0",
+                "util": "0.10.3",
+                "vm-browserify": "0.0.4"
+            }
+        },
+        "normalize-package-data": {
+            "version": "2.4.0",
+            "resolved": "http://registry.npm.taobao.org/normalize-package-data/download/normalize-package-data-2.4.0.tgz",
+            "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+            "requires": {
+                "hosted-git-info": "2.5.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.5.0",
+                "validate-npm-package-license": "3.0.1"
+            }
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved": "http://registry.npm.taobao.org/normalize-path/download/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "requires": {
+                "remove-trailing-separator": "1.1.0"
+            }
+        },
         "normalize-range": {
             "version": "0.1.2",
             "resolved": "http://registry.npm.taobao.org/normalize-range/download/normalize-range-0.1.2.tgz",
             "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "http://registry.npm.taobao.org/npm-run-path/download/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "requires": {
+                "path-key": "2.0.1"
+            }
         },
         "num2fraction": {
             "version": "1.2.2",
             "resolved": "http://registry.npm.taobao.org/num2fraction/download/num2fraction-1.2.2.tgz",
             "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
         },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npm.taobao.org/number-is-nan/download/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "http://registry.npm.taobao.org/object.omit/download/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+            }
+        },
         "onecolor": {
             "version": "3.0.5",
             "resolved": "http://registry.npm.taobao.org/onecolor/download/onecolor-3.0.5.tgz",
             "integrity": "sha1-Nu/zIgE3nv3xGA+0ReUajiQl+fY="
         },
+        "os-browserify": {
+            "version": "0.3.0",
+            "resolved": "http://registry.npm.taobao.org/os-browserify/download/os-browserify-0.3.0.tgz",
+            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+        },
+        "os-locale": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npm.taobao.org/os-locale/download/os-locale-2.1.0.tgz",
+            "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+            "requires": {
+                "execa": "0.7.0",
+                "lcid": "1.0.0",
+                "mem": "1.1.0"
+            }
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/p-finally/download/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        },
+        "p-limit": {
+            "version": "1.2.0",
+            "resolved": "http://registry.npm.taobao.org/p-limit/download/p-limit-1.2.0.tgz",
+            "integrity": "sha1-DpK2vty1nwIsE9DxlJ3ILRWQnxw=",
+            "requires": {
+                "p-try": "1.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "2.0.0",
+            "resolved": "http://registry.npm.taobao.org/p-locate/download/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "requires": {
+                "p-limit": "1.2.0"
+            }
+        },
+        "p-try": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/p-try/download/p-try-1.0.0.tgz",
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        },
+        "pako": {
+            "version": "1.0.6",
+            "resolved": "http://registry.npm.taobao.org/pako/download/pako-1.0.6.tgz",
+            "integrity": "sha1-AQEhG6pwxLykoPY/Igbpe3368lg="
+        },
+        "parse-asn1": {
+            "version": "5.1.0",
+            "resolved": "http://registry.npm.taobao.org/parse-asn1/download/parse-asn1-5.1.0.tgz",
+            "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+            "requires": {
+                "asn1.js": "4.9.2",
+                "browserify-aes": "1.1.1",
+                "create-hash": "1.1.3",
+                "evp_bytestokey": "1.0.3",
+                "pbkdf2": "3.0.14"
+            }
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "http://registry.npm.taobao.org/parse-glob/download/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+            }
+        },
+        "parse-json": {
+            "version": "2.2.0",
+            "resolved": "http://registry.npm.taobao.org/parse-json/download/parse-json-2.2.0.tgz",
+            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "requires": {
+                "error-ex": "1.3.1"
+            }
+        },
+        "path-browserify": {
+            "version": "0.0.0",
+            "resolved": "http://registry.npm.taobao.org/path-browserify/download/path-browserify-0.0.0.tgz",
+            "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
+        },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "http://registry.npm.taobao.org/path-exists/download/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npm.taobao.org/path-is-absolute/download/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "http://registry.npm.taobao.org/path-key/download/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+        },
         "path-parse": {
             "version": "1.0.5",
             "resolved": "http://registry.npm.taobao.org/path-parse/download/path-parse-1.0.5.tgz",
             "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+        },
+        "path-type": {
+            "version": "2.0.0",
+            "resolved": "http://registry.npm.taobao.org/path-type/download/path-type-2.0.0.tgz",
+            "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+            "requires": {
+                "pify": "2.3.0"
+            }
+        },
+        "pbkdf2": {
+            "version": "3.0.14",
+            "resolved": "http://registry.npm.taobao.org/pbkdf2/download/pbkdf2-3.0.14.tgz",
+            "integrity": "sha1-o14TxkeZsGzhUyD0WcIw5o5zut4=",
+            "requires": {
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "ripemd160": "2.0.1",
+                "safe-buffer": "5.1.1",
+                "sha.js": "2.4.10"
+            }
         },
         "performance-now": {
             "version": "2.1.0",
@@ -698,6 +2777,58 @@
             "resolved": "http://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.0.tgz",
             "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
         },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "http://registry.npm.taobao.org/preserve/download/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+        },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "http://registry.npm.taobao.org/process/download/process-0.11.10.tgz",
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+        },
+        "process-nextick-args": {
+            "version": "1.0.7",
+            "resolved": "http://registry.npm.taobao.org/process-nextick-args/download/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "prr": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npm.taobao.org/prr/download/prr-1.0.1.tgz",
+            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "http://registry.npm.taobao.org/pseudomap/download/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+        },
+        "public-encrypt": {
+            "version": "4.0.0",
+            "resolved": "http://registry.npm.taobao.org/public-encrypt/download/public-encrypt-4.0.0.tgz",
+            "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+            "requires": {
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.1.3",
+                "parse-asn1": "5.1.0",
+                "randombytes": "2.0.6"
+            }
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved": "http://registry.npm.taobao.org/punycode/download/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "http://registry.npm.taobao.org/querystring/download/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+        },
+        "querystring-es3": {
+            "version": "0.2.1",
+            "resolved": "http://registry.npm.taobao.org/querystring-es3/download/querystring-es3-0.2.1.tgz",
+            "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+        },
         "raf": {
             "version": "3.4.0",
             "resolved": "http://registry.npm.taobao.org/raf/download/raf-3.4.0.tgz",
@@ -706,12 +2837,110 @@
                 "performance-now": "2.1.0"
             }
         },
+        "randomatic": {
+            "version": "1.1.7",
+            "resolved": "http://registry.npm.taobao.org/randomatic/download/randomatic-1.1.7.tgz",
+            "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "http://registry.npm.taobao.org/is-number/download/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "randombytes": {
+            "version": "2.0.6",
+            "resolved": "http://registry.npm.taobao.org/randombytes/download/randombytes-2.0.6.tgz",
+            "integrity": "sha1-0wLFIpSFiISKjTAMkytEwkIx2oA=",
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "randomfill": {
+            "version": "1.0.3",
+            "resolved": "http://registry.npm.taobao.org/randomfill/download/randomfill-1.0.3.tgz",
+            "integrity": "sha1-uWt99YfwHdkXJsQY8wVTsUGOPWI=",
+            "requires": {
+                "randombytes": "2.0.6",
+                "safe-buffer": "5.1.1"
+            }
+        },
         "read-cache": {
             "version": "1.0.0",
             "resolved": "http://registry.npm.taobao.org/read-cache/download/read-cache-1.0.0.tgz",
             "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
             "requires": {
                 "pify": "2.3.0"
+            }
+        },
+        "read-pkg": {
+            "version": "2.0.0",
+            "resolved": "http://registry.npm.taobao.org/read-pkg/download/read-pkg-2.0.0.tgz",
+            "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+            "requires": {
+                "load-json-file": "2.0.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "2.0.0"
+            }
+        },
+        "read-pkg-up": {
+            "version": "2.0.0",
+            "resolved": "http://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-2.0.0.tgz",
+            "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+            "requires": {
+                "find-up": "2.1.0",
+                "read-pkg": "2.0.0"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.3",
+            "resolved": "http://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.3.tgz",
+            "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+            }
+        },
+        "readdirp": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npm.taobao.org/readdirp/download/readdirp-2.1.0.tgz",
+            "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "minimatch": "3.0.4",
+                "readable-stream": "2.3.3",
+                "set-immediate-shim": "1.0.1"
             }
         },
         "reduce-css-calc": {
@@ -737,6 +2966,39 @@
             "resolved": "http://registry.npm.taobao.org/regenerator-runtime/download/regenerator-runtime-0.11.1.tgz",
             "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
         },
+        "regex-cache": {
+            "version": "0.4.4",
+            "resolved": "http://registry.npm.taobao.org/regex-cache/download/regex-cache-0.4.4.tgz",
+            "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+            "requires": {
+                "is-equal-shallow": "0.1.3"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npm.taobao.org/remove-trailing-separator/download/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+        },
+        "repeat-element": {
+            "version": "1.1.2",
+            "resolved": "http://registry.npm.taobao.org/repeat-element/download/repeat-element-1.1.2.tgz",
+            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "http://registry.npm.taobao.org/repeat-string/download/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "http://registry.npm.taobao.org/require-directory/download/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+        },
+        "require-main-filename": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npm.taobao.org/require-main-filename/download/require-main-filename-1.0.1.tgz",
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+        },
         "resolve": {
             "version": "1.5.0",
             "resolved": "http://registry.npm.taobao.org/resolve/download/resolve-1.5.0.tgz",
@@ -755,6 +3017,75 @@
             "resolved": "http://registry.npm.taobao.org/rgb-hex/download/rgb-hex-2.1.0.tgz",
             "integrity": "sha1-x3PF/iJoolV42SU5qCp6XOU77aY="
         },
+        "right-align": {
+            "version": "0.1.3",
+            "resolved": "http://registry.npm.taobao.org/right-align/download/right-align-0.1.3.tgz",
+            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "requires": {
+                "align-text": "0.1.4"
+            }
+        },
+        "ripemd160": {
+            "version": "2.0.1",
+            "resolved": "http://registry.npm.taobao.org/ripemd160/download/ripemd160-2.0.1.tgz",
+            "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+            "requires": {
+                "hash-base": "2.0.2",
+                "inherits": "2.0.3"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.1",
+            "resolved": "http://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.1.1.tgz",
+            "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+        },
+        "semver": {
+            "version": "5.5.0",
+            "resolved": "http://registry.npm.taobao.org/semver/download/semver-5.5.0.tgz",
+            "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs="
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "http://registry.npm.taobao.org/set-blocking/download/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+        },
+        "set-immediate-shim": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npm.taobao.org/set-immediate-shim/download/set-immediate-shim-1.0.1.tgz",
+            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+        },
+        "setimmediate": {
+            "version": "1.0.5",
+            "resolved": "http://registry.npm.taobao.org/setimmediate/download/setimmediate-1.0.5.tgz",
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+        },
+        "sha.js": {
+            "version": "2.4.10",
+            "resolved": "http://registry.npm.taobao.org/sha.js/download/sha.js-2.4.10.tgz",
+            "integrity": "sha1-sf3lzX0RpWJmOKB8YEq5Cc+jH5s=",
+            "requires": {
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "http://registry.npm.taobao.org/shebang-command/download/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "requires": {
+                "shebang-regex": "1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/shebang-regex/download/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "http://registry.npm.taobao.org/signal-exit/download/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+        },
         "simple-swizzle": {
             "version": "0.2.2",
             "resolved": "http://registry.npm.taobao.org/simple-swizzle/download/simple-swizzle-0.2.2.tgz",
@@ -763,10 +3094,109 @@
                 "is-arrayish": "0.3.1"
             }
         },
+        "source-list-map": {
+            "version": "2.0.0",
+            "resolved": "http://registry.npm.taobao.org/source-list-map/download/source-list-map-2.0.0.tgz",
+            "integrity": "sha1-qqR0A/eyRakvvJfqCPJQ1gh+0IU="
+        },
         "source-map": {
             "version": "0.6.1",
             "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
             "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        },
+        "spdx-correct": {
+            "version": "1.0.2",
+            "resolved": "http://registry.npm.taobao.org/spdx-correct/download/spdx-correct-1.0.2.tgz",
+            "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+            "requires": {
+                "spdx-license-ids": "1.2.2"
+            }
+        },
+        "spdx-expression-parse": {
+            "version": "1.0.4",
+            "resolved": "http://registry.npm.taobao.org/spdx-expression-parse/download/spdx-expression-parse-1.0.4.tgz",
+            "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+        },
+        "spdx-license-ids": {
+            "version": "1.2.2",
+            "resolved": "http://registry.npm.taobao.org/spdx-license-ids/download/spdx-license-ids-1.2.2.tgz",
+            "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+        },
+        "stream-browserify": {
+            "version": "2.0.1",
+            "resolved": "http://registry.npm.taobao.org/stream-browserify/download/stream-browserify-2.0.1.tgz",
+            "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3"
+            }
+        },
+        "stream-http": {
+            "version": "2.8.0",
+            "resolved": "http://registry.npm.taobao.org/stream-http/download/stream-http-2.8.0.tgz",
+            "integrity": "sha1-/YZUbaybHJGv+PxdKHuY+vtBvBA=",
+            "requires": {
+                "builtin-status-codes": "3.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "to-arraybuffer": "1.0.1",
+                "xtend": "4.0.1"
+            }
+        },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "http://registry.npm.taobao.org/string-width/download/string-width-2.1.1.tgz",
+            "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+            "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "http://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "requires": {
+                        "ansi-regex": "3.0.0"
+                    }
+                }
+            }
+        },
+        "string_decoder": {
+            "version": "1.0.3",
+            "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.0.3.tgz",
+            "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "strip-bom": {
+            "version": "3.0.0",
+            "resolved": "http://registry.npm.taobao.org/strip-bom/download/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "http://registry.npm.taobao.org/strip-eof/download/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "supports-color": {
             "version": "5.1.0",
@@ -775,6 +3205,63 @@
             "requires": {
                 "has-flag": "2.0.0"
             }
+        },
+        "tapable": {
+            "version": "0.2.8",
+            "resolved": "http://registry.npm.taobao.org/tapable/download/tapable-0.2.8.tgz",
+            "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
+        },
+        "timers-browserify": {
+            "version": "2.0.6",
+            "resolved": "http://registry.npm.taobao.org/timers-browserify/download/timers-browserify-2.0.6.tgz",
+            "integrity": "sha1-JB52kn2coF9NlZgZAi9bNmS2S64=",
+            "requires": {
+                "setimmediate": "1.0.5"
+            }
+        },
+        "to-arraybuffer": {
+            "version": "1.0.1",
+            "resolved": "http://registry.npm.taobao.org/to-arraybuffer/download/to-arraybuffer-1.0.1.tgz",
+            "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+        },
+        "tty-browserify": {
+            "version": "0.0.0",
+            "resolved": "http://registry.npm.taobao.org/tty-browserify/download/tty-browserify-0.0.0.tgz",
+            "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+        },
+        "uglify-js": {
+            "version": "2.8.29",
+            "resolved": "http://registry.npm.taobao.org/uglify-js/download/uglify-js-2.8.29.tgz",
+            "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+            "requires": {
+                "source-map": "0.5.7",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+                },
+                "yargs": {
+                    "version": "3.10.0",
+                    "resolved": "http://registry.npm.taobao.org/yargs/download/yargs-3.10.0.tgz",
+                    "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                    "requires": {
+                        "camelcase": "1.2.1",
+                        "cliui": "2.1.0",
+                        "decamelize": "1.2.0",
+                        "window-size": "0.1.0"
+                    }
+                }
+            }
+        },
+        "uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved": "http://registry.npm.taobao.org/uglify-to-browserify/download/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "optional": true
         },
         "uniq": {
             "version": "1.0.1",
@@ -790,10 +3277,257 @@
                 "viewport-dimensions": "0.2.0"
             }
         },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "http://registry.npm.taobao.org/url/download/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "http://registry.npm.taobao.org/punycode/download/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+                }
+            }
+        },
+        "util": {
+            "version": "0.10.3",
+            "resolved": "http://registry.npm.taobao.org/util/download/util-0.10.3.tgz",
+            "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+            "requires": {
+                "inherits": "2.0.1"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.1",
+                    "resolved": "http://registry.npm.taobao.org/inherits/download/inherits-2.0.1.tgz",
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                }
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "http://registry.npm.taobao.org/util-deprecate/download/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.1",
+            "resolved": "http://registry.npm.taobao.org/validate-npm-package-license/download/validate-npm-package-license-3.0.1.tgz",
+            "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+            "requires": {
+                "spdx-correct": "1.0.2",
+                "spdx-expression-parse": "1.0.4"
+            }
+        },
         "viewport-dimensions": {
             "version": "0.2.0",
             "resolved": "http://registry.npm.taobao.org/viewport-dimensions/download/viewport-dimensions-0.2.0.tgz",
             "integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w="
+        },
+        "vm-browserify": {
+            "version": "0.0.4",
+            "resolved": "http://registry.npm.taobao.org/vm-browserify/download/vm-browserify-0.0.4.tgz",
+            "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+            "requires": {
+                "indexof": "0.0.1"
+            }
+        },
+        "watchpack": {
+            "version": "1.4.0",
+            "resolved": "http://registry.npm.taobao.org/watchpack/download/watchpack-1.4.0.tgz",
+            "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
+            "requires": {
+                "async": "2.6.0",
+                "chokidar": "1.7.0",
+                "graceful-fs": "4.1.11"
+            }
+        },
+        "webpack": {
+            "version": "3.10.0",
+            "resolved": "http://registry.npm.taobao.org/webpack/download/webpack-3.10.0.tgz",
+            "integrity": "sha1-UpG4dQeM8qv0K90jr+P4+WwX1yU=",
+            "requires": {
+                "acorn": "5.3.0",
+                "acorn-dynamic-import": "2.0.2",
+                "ajv": "5.5.2",
+                "ajv-keywords": "2.1.1",
+                "async": "2.6.0",
+                "enhanced-resolve": "3.4.1",
+                "escope": "3.6.0",
+                "interpret": "1.1.0",
+                "json-loader": "0.5.7",
+                "json5": "0.5.1",
+                "loader-runner": "2.3.0",
+                "loader-utils": "1.1.0",
+                "memory-fs": "0.4.1",
+                "mkdirp": "0.5.1",
+                "node-libs-browser": "2.1.0",
+                "source-map": "0.5.7",
+                "supports-color": "4.5.0",
+                "tapable": "0.2.8",
+                "uglifyjs-webpack-plugin": "0.4.6",
+                "watchpack": "1.4.0",
+                "webpack-sources": "1.1.0",
+                "yargs": "8.0.2"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "http://registry.npm.taobao.org/camelcase/download/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved": "http://registry.npm.taobao.org/cliui/download/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wrap-ansi": "2.1.0"
+                    },
+                    "dependencies": {
+                        "string-width": {
+                            "version": "1.0.2",
+                            "resolved": "http://registry.npm.taobao.org/string-width/download/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "requires": {
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
+                            }
+                        }
+                    }
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+                },
+                "supports-color": {
+                    "version": "4.5.0",
+                    "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-4.5.0.tgz",
+                    "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+                    "requires": {
+                        "has-flag": "2.0.0"
+                    }
+                },
+                "uglifyjs-webpack-plugin": {
+                    "version": "0.4.6",
+                    "resolved": "http://registry.npm.taobao.org/uglifyjs-webpack-plugin/download/uglifyjs-webpack-plugin-0.4.6.tgz",
+                    "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
+                    "requires": {
+                        "source-map": "0.5.7",
+                        "uglify-js": "2.8.29",
+                        "webpack-sources": "1.1.0"
+                    }
+                },
+                "yargs": {
+                    "version": "8.0.2",
+                    "resolved": "http://registry.npm.taobao.org/yargs/download/yargs-8.0.2.tgz",
+                    "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+                    "requires": {
+                        "camelcase": "4.1.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "2.1.0",
+                        "read-pkg-up": "2.0.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.1.1",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "7.0.0"
+                    }
+                }
+            }
+        },
+        "webpack-sources": {
+            "version": "1.1.0",
+            "resolved": "http://registry.npm.taobao.org/webpack-sources/download/webpack-sources-1.1.0.tgz",
+            "integrity": "sha1-oQHrrlnWUHNU1x2AE5UKOot6WlQ=",
+            "requires": {
+                "source-list-map": "2.0.0",
+                "source-map": "0.6.1"
+            }
+        },
+        "which": {
+            "version": "1.3.0",
+            "resolved": "http://registry.npm.taobao.org/which/download/which-1.3.0.tgz",
+            "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+            "requires": {
+                "isexe": "2.0.0"
+            }
+        },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "http://registry.npm.taobao.org/which-module/download/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+        },
+        "window-size": {
+            "version": "0.1.0",
+            "resolved": "http://registry.npm.taobao.org/window-size/download/window-size-0.1.0.tgz",
+            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+        },
+        "wordwrap": {
+            "version": "0.0.2",
+            "resolved": "http://registry.npm.taobao.org/wordwrap/download/wordwrap-0.0.2.tgz",
+            "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "http://registry.npm.taobao.org/wrap-ansi/download/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "requires": {
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
+            },
+            "dependencies": {
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "http://registry.npm.taobao.org/string-width/download/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                    }
+                }
+            }
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "http://registry.npm.taobao.org/xtend/download/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        },
+        "y18n": {
+            "version": "3.2.1",
+            "resolved": "http://registry.npm.taobao.org/y18n/download/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved": "http://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        },
+        "yargs-parser": {
+            "version": "7.0.0",
+            "resolved": "http://registry.npm.taobao.org/yargs-parser/download/yargs-parser-7.0.0.tgz",
+            "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+            "requires": {
+                "camelcase": "4.1.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "http://registry.npm.taobao.org/camelcase/download/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+                }
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
         "optimize-css-assets-webpack-plugin": "^3.2.0",
         "ora": "^1.3.0",
         "portscanner": "^2.1.1",
-        "postcss-cssnext": "^3.1.0",
         "postcss-flexbugs-fixes": "^3.3.0",
         "postcss-import": "^11.0.0",
         "postcss-loader": "^2.0.10",
+        "postcss-preset-env": "^2.1.0",
         "postcss-url": "^7.3.0",
         "promise-polyfill": "^6.1.0",
         "raf": "^3.4.0",
@@ -98,9 +98,6 @@
         "prettier": "^1.10.2"
     },
     "lint-staged": {
-        "**/*.{js,json}": [
-            "prettier",
-            "git add"
-        ]
+        "**/*.{js,json}": ["prettier", "git add"]
     }
 }

--- a/package.json
+++ b/package.json
@@ -102,12 +102,5 @@
             "prettier",
             "git add"
         ]
-    },
-    "browserslist": [
-        "> 1%",
-        "last 4 versions",
-        "ios >= 8",
-        "android >= 4.1",
-        "not ie < 9"
-    ]
+    }
 }

--- a/webpack/loaders/style-loader.js
+++ b/webpack/loaders/style-loader.js
@@ -12,22 +12,20 @@ const cssFilename = maraConf.hash
 const shouldUseRelativeAssetPaths = maraConf.publicPath === './'
 
 const postcssPlugin = [
+  require('postcss-flexbugs-fixes'),
+  autoprefixer(config.postcss)
+]
+
+// css 语法增强
+const postcssPluginAdvanced = [
   // 提供代码段引入，为了保证引入的代码段能够享受后续的配置
   // 应确保此插件在插件列表中处于第一位
   // https://github.com/postcss/postcss-import
   require('postcss-import')(),
   // 辅助 postcss-import 插件， 解决嵌套层级的图片资源路径问题
   require('postcss-url')(),
-  require('postcss-flexbugs-fixes'),
-  require('postcss-cssnext')(config.postcss)
-]
-
-// 与预处理器集成
-// 由于预处理器拥有自定义语法
-// 所以这里不使用 cssnext import 等 postcss 语法增强插件
-const postcssWithPreProcessors = [
-  autoprefixer(config.postcss),
-  require('postcss-flexbugs-fixes')
+  require('postcss-preset-env')(config.postcss),
+  ...postcssPlugin
 ]
 
 // Extract CSS when that option is specified
@@ -77,7 +75,7 @@ function cssLoaders(options = {}) {
     const postcssLoader = {
       loader: 'postcss-loader',
       options: {
-        plugins: loader ? postcssWithPreProcessors : postcssPlugin,
+        plugins: loader ? postcssPlugin : postcssPluginAdvanced,
         sourceMap: options.sourceMap
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,6 +62,10 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@csstools/convert-colors@^1.3":
+  version "1.4.0"
+  resolved "http://registry.npm.taobao.org/@csstools/convert-colors/download/@csstools/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -379,7 +383,7 @@ async@1.5.2, async@^1.4.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.npmjs.org/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.2, async@^2.1.4, async@^2.3.0, async@^2.4.1:
+async@^2.1.2, async@^2.1.4, async@^2.4.1:
   version "2.6.0"
   resolved "https://registry.npmjs.org/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
@@ -1313,7 +1317,7 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
 
-browserslist@^2.0.0, browserslist@^2.1.2, browserslist@^2.11.1, browserslist@^2.11.3:
+browserslist@^2.0.0, browserslist@^2.1.2, browserslist@^2.11, browserslist@^2.11.1, browserslist@^2.11.3, browserslist@^2.4.0:
   version "2.11.3"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
   dependencies:
@@ -1460,7 +1464,7 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000798"
   resolved "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000798.tgz#92f26f77f89cc2a4d60487f41e0b3d2a6c3fe341"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000791, caniuse-lite@^1.0.30000792:
+caniuse-lite@^1.0, caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000791, caniuse-lite@^1.0.30000792:
   version "1.0.30000792"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz#d0cea981f8118f3961471afbb43c9a1e5bbf0332"
 
@@ -2056,6 +2060,10 @@ css-unit-converter@^1.1.1:
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
+
+cssdb@^1.5:
+  version "1.5.0"
+  resolved "http://registry.npm.taobao.org/cssdb/download/cssdb-1.5.0.tgz#e6179657bf96eb063eb316b2f5a5f4c4a2633df7"
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -6007,7 +6015,7 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
-postcss-apply@^0.8.0:
+postcss-apply@^0.8, postcss-apply@^0.8.0:
   version "0.8.0"
   resolved "https://registry.npmjs.org/postcss-apply/-/postcss-apply-0.8.0.tgz#14e544bbb5cb6f1c1e048857965d79ae066b1343"
   dependencies:
@@ -6015,7 +6023,7 @@ postcss-apply@^0.8.0:
     balanced-match "^0.4.2"
     postcss "^6.0.0"
 
-postcss-attribute-case-insensitive@^2.0.0:
+postcss-attribute-case-insensitive@^2.0, postcss-attribute-case-insensitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-2.0.0.tgz#94dc422c8f90997f16bd33a3654bbbec084963b4"
   dependencies:
@@ -6057,7 +6065,7 @@ postcss-color-gray@^4.0.0:
     postcss-message-helpers "^2.0.0"
     reduce-function-call "^1.0.2"
 
-postcss-color-hex-alpha@^3.0.0:
+postcss-color-hex-alpha@^3.0, postcss-color-hex-alpha@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-3.0.0.tgz#1e53e6c8acb237955e8fd08b7ecdb1b8b8309f95"
   dependencies:
@@ -6082,7 +6090,15 @@ postcss-color-hwb@^3.0.0:
     postcss-message-helpers "^2.0.0"
     reduce-function-call "^1.0.2"
 
-postcss-color-rebeccapurple@^3.0.0:
+postcss-color-mod-function@^2.2:
+  version "2.3.0"
+  resolved "http://registry.npm.taobao.org/postcss-color-mod-function/download/postcss-color-mod-function-2.3.0.tgz#56ba67d7fadccf190795efbc529b015c8fa68fdc"
+  dependencies:
+    "@csstools/convert-colors" "^1.3"
+    postcss "^6.0"
+    postcss-values-parser "^1.3"
+
+postcss-color-rebeccapurple@^3.0, postcss-color-rebeccapurple@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-3.0.0.tgz#eebaf03d363b4300b96792bd3081c19ed66513d3"
   dependencies:
@@ -6119,9 +6135,9 @@ postcss-convert-values@^2.3.4:
     postcss "^5.0.11"
     postcss-value-parser "^3.1.2"
 
-postcss-cssnext@^3.0.2:
+postcss-cssnext@^3.1.0:
   version "3.1.0"
-  resolved "https://registry.npmjs.org/postcss-cssnext/-/postcss-cssnext-3.1.0.tgz#927dc29341a938254cde38ea60a923b9dfedead9"
+  resolved "http://registry.npm.taobao.org/postcss-cssnext/download/postcss-cssnext-3.1.0.tgz#927dc29341a938254cde38ea60a923b9dfedead9"
   dependencies:
     autoprefixer "^7.1.1"
     caniuse-api "^2.0.0"
@@ -6155,25 +6171,33 @@ postcss-cssnext@^3.0.2:
     postcss-selector-matches "^3.0.1"
     postcss-selector-not "^3.0.1"
 
-postcss-custom-media@^6.0.0:
+postcss-custom-media@^6.0, postcss-custom-media@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-6.0.0.tgz#be532784110ecb295044fb5395a18006eb21a737"
   dependencies:
     postcss "^6.0.1"
 
-postcss-custom-properties@^6.1.0:
+postcss-custom-properties@^6.1.0, postcss-custom-properties@^6.2:
   version "6.2.0"
   resolved "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-6.2.0.tgz#5d929a7f06e9b84e0f11334194c0ba9a30acfbe9"
   dependencies:
     balanced-match "^1.0.0"
     postcss "^6.0.13"
 
-postcss-custom-selectors@^4.0.1:
+postcss-custom-selectors@^4.0, postcss-custom-selectors@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-4.0.1.tgz#781382f94c52e727ef5ca4776ea2adf49a611382"
   dependencies:
     postcss "^6.0.1"
     postcss-selector-matches "^3.0.0"
+
+postcss-dir-pseudo-class@^2.1:
+  version "2.1.0"
+  resolved "http://registry.npm.taobao.org/postcss-dir-pseudo-class/download/postcss-dir-pseudo-class-2.1.0.tgz#d441b000688d0ecdd88cc040da922e72b62cf830"
+  dependencies:
+    browserslist "^2.4.0"
+    postcss "^6.0.11"
+    postcss-selector-parser "^2.2.3"
 
 postcss-discard-comments@^2.0.4:
   version "2.0.4"
@@ -6219,13 +6243,13 @@ postcss-flexbugs-fixes@^3.3.0:
   dependencies:
     postcss "^6.0.1"
 
-postcss-font-family-system-ui@^3.0.0:
+postcss-font-family-system-ui@^3.0, postcss-font-family-system-ui@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/postcss-font-family-system-ui/-/postcss-font-family-system-ui-3.0.0.tgz#675fe7a9e029669f05f8dba2e44c2225ede80623"
   dependencies:
     postcss "^6.0"
 
-postcss-font-variant@^3.0.0:
+postcss-font-variant@^3.0, postcss-font-variant@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-3.0.0.tgz#08ccc88f6050ba82ed8ef2cc76c0c6a6b41f183e"
   dependencies:
@@ -6238,6 +6262,14 @@ postcss-image-set-polyfill@^0.3.5:
     postcss "^6.0.1"
     postcss-media-query-parser "^0.2.3"
 
+postcss-image-set-polyfill@^0.4:
+  version "0.4.4"
+  resolved "http://registry.npm.taobao.org/postcss-image-set-polyfill/download/postcss-image-set-polyfill-0.4.4.tgz#5acdebd25aeb237dde0791c524b68947400995f8"
+  dependencies:
+    postcss "6.0.1"
+    postcss-media-query-parser "0.2.3"
+    postcss-value-parser "3.3.0"
+
 postcss-import@^11.0.0:
   version "11.0.0"
   resolved "https://registry.npmjs.org/postcss-import/-/postcss-import-11.0.0.tgz#a962e2df82d3bc5a6da6a386841747204f41ef5b"
@@ -6247,7 +6279,7 @@ postcss-import@^11.0.0:
     read-cache "^1.0.0"
     resolve "^1.1.7"
 
-postcss-initial@^2.0.0:
+postcss-initial@^2.0, postcss-initial@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/postcss-initial/-/postcss-initial-2.0.0.tgz#72715f7336e0bb79351d99ee65c4a253a8441ba4"
   dependencies:
@@ -6286,13 +6318,19 @@ postcss-loader@^2.0.10:
     postcss-load-config "^1.2.0"
     schema-utils "^0.3.0"
 
-postcss-media-minmax@^3.0.0:
+postcss-logical@^1.0:
+  version "1.0.2"
+  resolved "http://registry.npm.taobao.org/postcss-logical/download/postcss-logical-1.0.2.tgz#b70199cc55676e48e2eca5421c58250b0c298c4a"
+  dependencies:
+    postcss "^6.0.9"
+
+postcss-media-minmax@^3.0, postcss-media-minmax@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-3.0.0.tgz#675256037a43ef40bc4f0760bfd06d4dc69d48d2"
   dependencies:
     postcss "^6.0.1"
 
-postcss-media-query-parser@^0.2.3:
+postcss-media-query-parser@0.2.3, postcss-media-query-parser@^0.2.3:
   version "0.2.3"
   resolved "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
 
@@ -6384,7 +6422,7 @@ postcss-modules-values@^1.3.0:
     icss-replace-symbols "^1.1.0"
     postcss "^6.0.1"
 
-postcss-nesting@^4.0.1:
+postcss-nesting@^4.0.1, postcss-nesting@^4.2:
   version "4.2.1"
   resolved "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-4.2.1.tgz#0483bce338b3f0828ced90ff530b29b98b00300d"
   dependencies:
@@ -6412,7 +6450,37 @@ postcss-ordered-values@^2.1.0:
     postcss "^5.0.4"
     postcss-value-parser "^3.0.1"
 
-postcss-pseudo-class-any-link@^4.0.0:
+postcss-preset-env@^2.1.0:
+  version "2.1.0"
+  resolved "http://registry.npm.taobao.org/postcss-preset-env/download/postcss-preset-env-2.1.0.tgz#1c3de84e11c5e14c1424a0fb66ad506089adfe7c"
+  dependencies:
+    browserslist "^2.11"
+    caniuse-lite "^1.0"
+    cssdb "^1.5"
+    postcss "^6.0"
+    postcss-apply "^0.8"
+    postcss-attribute-case-insensitive "^2.0"
+    postcss-color-hex-alpha "^3.0"
+    postcss-color-mod-function "^2.2"
+    postcss-color-rebeccapurple "^3.0"
+    postcss-color-rgb "^2.0.0"
+    postcss-custom-media "^6.0"
+    postcss-custom-properties "^6.2"
+    postcss-custom-selectors "^4.0"
+    postcss-dir-pseudo-class "^2.1"
+    postcss-font-family-system-ui "^3.0"
+    postcss-font-variant "^3.0"
+    postcss-image-set-polyfill "^0.4"
+    postcss-initial "^2.0"
+    postcss-logical "^1.0"
+    postcss-media-minmax "^3.0"
+    postcss-nesting "^4.2"
+    postcss-pseudo-class-any-link "^4.0"
+    postcss-replace-overflow-wrap "^2.0"
+    postcss-selector-matches "^3.0"
+    postcss-selector-not "^3.0"
+
+postcss-pseudo-class-any-link@^4.0, postcss-pseudo-class-any-link@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-4.0.0.tgz#9152a0613d3450720513e8892854bae42d0ee68e"
   dependencies:
@@ -6446,20 +6514,20 @@ postcss-reduce-transforms@^1.0.3:
     postcss "^5.0.8"
     postcss-value-parser "^3.0.1"
 
-postcss-replace-overflow-wrap@^2.0.0:
+postcss-replace-overflow-wrap@^2.0, postcss-replace-overflow-wrap@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-2.0.0.tgz#794db6faa54f8db100854392a93af45768b4e25b"
   dependencies:
     postcss "^6.0.1"
 
-postcss-selector-matches@^3.0.0, postcss-selector-matches@^3.0.1:
+postcss-selector-matches@^3.0, postcss-selector-matches@^3.0.0, postcss-selector-matches@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-3.0.1.tgz#e5634011e13950881861bbdd58c2d0111ffc96ab"
   dependencies:
     balanced-match "^0.4.2"
     postcss "^6.0.1"
 
-postcss-selector-not@^3.0.1:
+postcss-selector-not@^3.0, postcss-selector-not@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-3.0.1.tgz#2e4db2f0965336c01e7cec7db6c60dff767335d9"
   dependencies:
@@ -6501,9 +6569,17 @@ postcss-url@^7.3.0:
     postcss "^6.0.1"
     xxhashjs "^0.2.1"
 
-postcss-value-parser@^3.0.1, postcss-value-parser@^3.0.2, postcss-value-parser@^3.1.1, postcss-value-parser@^3.1.2, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
+postcss-value-parser@3.3.0, postcss-value-parser@^3.0.1, postcss-value-parser@^3.0.2, postcss-value-parser@^3.1.1, postcss-value-parser@^3.1.2, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
+
+postcss-values-parser@^1.3:
+  version "1.3.1"
+  resolved "http://registry.npm.taobao.org/postcss-values-parser/download/postcss-values-parser-1.3.1.tgz#2a6ceb39cecbbacd1d060f3b16f4c52dd6720c96"
+  dependencies:
+    flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
 
 postcss-zindex@^2.0.1:
   version "2.2.0"
@@ -6512,6 +6588,14 @@ postcss-zindex@^2.0.1:
     has "^1.0.1"
     postcss "^5.0.4"
     uniqs "^2.0.0"
+
+postcss@6.0.1:
+  version "6.0.1"
+  resolved "http://registry.npm.taobao.org/postcss/download/postcss-6.0.1.tgz#000dbd1f8eef217aa368b9a212c5fc40b2a8f3f2"
+  dependencies:
+    chalk "^1.1.3"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
 
 postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.2, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8, postcss@^5.2.16:
   version "5.2.18"
@@ -6525,6 +6609,14 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
 postcss@^6.0, postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.11, postcss@^6.0.13, postcss@^6.0.14, postcss@^6.0.16, postcss@^6.0.5, postcss@^6.0.6, postcss@^6.0.8:
   version "6.0.16"
   resolved "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz#112e2fe2a6d2109be0957687243170ea5589e146"
+  dependencies:
+    chalk "^2.3.0"
+    source-map "^0.6.1"
+    supports-color "^5.1.0"
+
+postcss@^6.0.9:
+  version "6.0.17"
+  resolved "http://registry.npm.taobao.org/postcss/download/postcss-6.0.17.tgz#e259a051ca513f81e9afd0c21f7f82eda50c65c5"
   dependencies:
     chalk "^2.3.0"
     source-map "^0.6.1"
@@ -7904,14 +7996,6 @@ test-exclude@^4.1.1:
 text-table@0.2.0, text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
-
-thread-loader@^1.1.2:
-  version "1.1.2"
-  resolved "http://registry.npm.taobao.org/thread-loader/download/thread-loader-1.1.2.tgz#45dd1af01d8e421e6002b3c19358650cb9a42518"
-  dependencies:
-    async "^2.3.0"
-    loader-runner "^2.3.0"
-    loader-utils "^1.1.0"
 
 throat@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
[autoprefixer](https://github.com/postcss/autoprefixer) 与 [babel-preset-env](https://github.com/babel/babel/tree/master/packages/babel-preset-env) 使用 [browserslist](https://github.com/ai/browserslist) 来读取浏览器配置

当项目中未存在 browsers 配置时，browserslist 会使用内置的默认配置：

```
browserslist.defaults = [
  '> 1%',
  'last 2 versions',
  'Firefox ESR'
]
```

在一些未设置 browserslist 的移动端项目中，将导致 css  与 js  语法特性转义不完全，在一些较旧的浏览器上可能会出现意料之外的 bug。
再者，browserslist 的配置内容符合定式，且一旦配置，未来很长一段时间内几无需变动。

所以在 webpack-marauder 中提供 browserslist 的默认配置处理，当项目中未检测到 browsers 配置时，将设置 process.env.BROWSERSLIST 以启用默认配置。

默认配置项遵循 `移动优先原则`：
```
browserslist: [
  '> 1%',
  'last 4 versions',
  'ios >= 8',
  'android >= 4.1',
  'not ie < 9'
]
```

当用户在项目中以任意合法方式配置了 browsers 信息时，webpack-marauder 将会禁用默认配置。