### PR TITLE
静态代码分割

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,26 @@ npm run build
 ```
 
 打包后文件将在 `lib` 目录中输出
+
+## 教程
+
+### 代码分割
+
+#### 动态代码分割
+
+@TODO
+
+#### 静态代码分割
+
+此功能可零配置启用，凡是在 `view/<page_name>/` 下符合命名约定 `index.<chunk_name>.js` 的文件均会被视为 `chunk` 包拆分，拆分后的 bundle 文件以 `<chunk_name>.servant.js` 命名，这里称之为 `servant` 包。
+
+其中 `chunk_name` 为拆分入口的名称，例如 `index.foo.js` 构建后将生成 `foo.servant.js`
+
+`<chunk_name>.servant.js` 文件将只会在生产环境(build)生成，在开发环境(dev)中，所有的 servant 将合并到 entry 中引入。对于使用者来说一切都是无感知的。
+
+**注意**
+由于 entry bundle 中已经包含 `polyfill`（Promise，Object.assign），为了避免打包不必要冗余，通过此方式拆分出的 servant 包将不包含 polyfill 内容。为安全起见，建议将 servant 包置于 entry 之后引入（除非您清楚 servant 中不会触发兼容性问题），这也是取名为 `servant` 的本意。`webpack-marauder` 已为您默认配置好一切。
+
+#### 打包 vendor
+
+@TODO

--- a/libs/utils.js
+++ b/libs/utils.js
@@ -59,16 +59,35 @@ async function getFreePort(defPort) {
  */
 function getEntries(globPath, preDep = []) {
   const files = glob.sync(rootPath(globPath))
-  const entries = {}
-
-  files.forEach(filepath => {
-    let dirname = path.dirname(path.relative('src/view/', filepath))
+  const getPageName = filepath => {
+    const dirname = path.dirname(path.relative('src/view/', filepath))
     // 兼容组件，src/index.js
-    dirname = dirname === '..' ? 'index' : dirname
-    entries[dirname] = [].concat(preDep, filepath)
-  })
+    return dirname === '..' ? 'index' : dirname
+  }
 
-  return entries
+  return files.reduce((entries, filepath) => {
+    const name = getPageName(filepath)
+    // preDep 支持数组或字符串。所以这里使用 concat 方法
+    entries[name] = [].concat(preDep, filepath)
+
+    return entries
+  }, {})
+}
+
+function getChunks(globPath, preDep = []) {
+  const files = glob.sync(rootPath(globPath))
+  const getTrunkName = filepath => {
+    const basename = path.posix.basename(filepath, '.js')
+    return basename.replace(/^index\./, '') + '.servant'
+  }
+
+  return files.reduce((trunks, filepath) => {
+    const name = getTrunkName(filepath)
+    // preDep 支持数组或字符串。所以这里使用 concat 方法
+    trunks[name] = [].concat(preDep, filepath)
+
+    return trunks
+  }, {})
 }
 
 /**
@@ -146,6 +165,7 @@ module.exports = {
   localIp,
   getFreePort,
   getEntries,
+  getChunks,
   rootPath,
   parseDate,
   pubDate,

--- a/webpack/webpack.base.conf.js
+++ b/webpack/webpack.base.conf.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const config = require('../config')
 const vueLoaderConfig = require('./loaders/vue-loader.conf')
-const { getEntries, nodeModulesRegExp } = require('../libs/utils')
+const { getEntries, getChunks, nodeModulesRegExp } = require('../libs/utils')
 const { styleLoaders } = require('./loaders/style-loader')
 const babelLoader = require('./loaders/babel-loader')
 const paths = config.paths
@@ -21,16 +21,31 @@ function babelExternalMoudles(esm) {
   return nodeModulesRegExp([].concat(config.esm, esm))
 }
 
+function parseEntry(entry) {
+  const entryGlob = `src/view/${entry}/index.js`
+  const chunkGlob = `src/view/${entry}/index.*.js`
+  const entryObj = getEntries(entryGlob, require.resolve('./polyfills'))
+  const chunkObj = getChunks(chunkGlob)
+  const chunks = Object.values(chunkObj).reduce(
+    (res, cur) => res.concat(cur),
+    []
+  )
+  const devEntry = { [entry]: entryObj[entry].concat(chunks) }
+  // 保证 entryObj 为第一位
+  const prodEntry = Object.assign(chunkObj, entryObj)
+
+  return { devEntry, prodEntry }
+}
+
 module.exports = function(entry) {
-  let entryGlob = `src/view/${entry || '*'}/index.js`
-  const entries = getEntries(entryGlob, require.resolve('./polyfills'))
+  const { devEntry, prodEntry } = parseEntry(entry)
 
   return {
-    entry: entries,
+    entry: isProd ? prodEntry : devEntry,
     output: {
       path: paths.dist,
       filename: 'static/js/[name].js',
-      chunkFilename: 'static/js/[name].chunk.js'
+      chunkFilename: 'static/js/[name].async.js'
     },
     resolve: {
       extensions: [

--- a/webpack/webpack.prod.conf.js
+++ b/webpack/webpack.prod.conf.js
@@ -45,8 +45,8 @@ module.exports = function({ entry }) {
         ? 'static/js/[name].[chunkhash:8].min.js'
         : 'static/js/[name].min.js',
       chunkFilename: maraConf.chunkHash
-        ? 'static/js/[name].[chunkhash:8].chunk.js'
-        : 'static/js/[name].chunk.js'
+        ? 'static/js/[name].[chunkhash:8].async.js'
+        : 'static/js/[name].async.js'
     },
     plugins: [
       new InterpolateHtmlPlugin(config.build.env.raw),

--- a/webpack/webpack.prod.conf.js
+++ b/webpack/webpack.prod.conf.js
@@ -20,18 +20,16 @@ const shouldUseSourceMap = !!maraConf.sourceMap
 // 压缩配置
 const compress = Object.assign(config.compress, maraConf.compress)
 
-// let configvendor = maraConf.vendor
-// if (configvendor == null || configvendor.length == 0) {
-//   configvendor = {}
-// } else {
-//   configvendor = {
-//     vendor: configvendor
-//   }
-// }
+function getChunksName(entry) {
+  const names = Object.keys(entry)
+
+  return names.filter(n => n.includes('.servant')).sort()
+}
 
 module.exports = function({ entry }) {
   const distPageDir = `${config.paths.dist}/${entry}`
   const baseWebpackConfig = require('./webpack.base.conf')(entry)
+  const chunkNames = getChunksName(baseWebpackConfig.entry)
 
   const webpackConfig = merge(baseWebpackConfig, {
     // 在第一个错误出错时抛出，而不是无视错误
@@ -132,8 +130,8 @@ module.exports = function({ entry }) {
             minify: false,
             // 自动将引用插入html
             inject: true,
-            // 每个html引用的js模块，也可以在这里加上vendor等公用模块
-            chunks: [name],
+            // 每个html引用的js模块
+            chunks: chunkNames.concat('common', name),
             collapseWhitespace: true,
             removeRedundantAttributes: true,
             useShortDoctype: true,
@@ -150,7 +148,7 @@ module.exports = function({ entry }) {
   // if (maraConf.vendor && maraConf.vendor.length) {
   //   webpackConfig.plugins.push(
   //     new webpack.optimize.CommonsChunkPlugin({
-  //       name: 'vendor',
+  //       name: 'common',
   //       minChunks: Infinity
   //     })
   //   )

--- a/webpack/webpack.prod.conf.js
+++ b/webpack/webpack.prod.conf.js
@@ -130,8 +130,11 @@ module.exports = function({ entry }) {
             minify: false,
             // 自动将引用插入html
             inject: true,
-            // 每个html引用的js模块
-            chunks: chunkNames.concat('common', name),
+            // 模块排序，common > entry > servant
+            chunksSortMode(a, b) {
+              const order = ['common', name].concat(chunkNames)
+              return order.indexOf(a.names[0]) - order.indexOf(b.names[0])
+            },
             collapseWhitespace: true,
             removeRedundantAttributes: true,
             useShortDoctype: true,


### PR DESCRIPTION
静态代码分割支持。

此功能可零配置启用，凡是在 `view/<page_name>/` 下符合命名约定 `index.<chunk_name>.js` 的文件均会以 `chunk` 包拆分，拆分后的 bundle 文件以 `<chunk_name>.servant.js` 命名，这里称之为 `servant` 包。

其中 `chunk_name` 为拆分文件的名称，例如 `index.foo.js` 构建后将生成 `foo.servant.js`

`<chunk_name>.servant.js` 文件将只会在生产环境(build)生成，在开发环境(dev)中，所有的 servant 将合并到 entry 中引入。对于使用者来说一切都是无感知的。


构建成功后，`webpack-marauder` 将会在 html  文件中注入 servant 资源。

**注意**
由于 entry bundle 中已经包含 `polyfill`（Promise，Object.assign），为了避免打包不必要冗余，通过此方式拆分出的 servant 包将不包含 polyfill 内容。为安全起见，请将 servant 包置于 entry 之后引入（除非您清楚 servant 中不会含有导致破坏的内容），这也是取名为 `servant` 的本意。

