### PR TITLE
组件打包输出 cjs  与 umd  格式, resolve #8

### DIFF
--- a/build/build4comp.js
+++ b/build/build4comp.js
@@ -25,10 +25,25 @@ const spinner = ora('Biuld component...')
 spinner.start()
 
 const pages = getPageList(config.paths.entries)
-const webpackConfs = [
-  getWebpackLibConf(maraConf.library),
-  ...pages.map(entry => getWebpackProdConf({ entry }))
+const targets = [
+  {
+    format: 'commonjs2',
+    filename: 'index.cjs.js'
+  },
+  {
+    format: 'umd',
+    filename: 'index.min.js',
+    minify: true
+  },
+  {
+    format: 'umd',
+    filename: 'index.js'
+  }
 ]
+
+const webpackConfs = targets
+  .map(library => getWebpackLibConf(library))
+  .concat(pages.map(entry => getWebpackProdConf({ entry })))
 
 function build() {
   const compiler = webpack(webpackConfs)
@@ -58,9 +73,9 @@ function build() {
 }
 
 function clean() {
-  const targets = [paths.dist, paths.lib]
+  const dists = [paths.dist, paths.lib]
 
-  return Promise.all(targets.map(dir => fs.emptyDir(dir)))
+  return Promise.all(dists.map(dir => fs.emptyDir(dir)))
 }
 
 function success(output) {

--- a/config/index.js
+++ b/config/index.js
@@ -28,6 +28,7 @@ module.exports = {
     amd: pkgName,
     commonjs: pkgName
   },
+  assetsDir: 'static',
   // 压缩配置
   compress: {
     // 移除 console

--- a/config/paths.js
+++ b/config/paths.js
@@ -9,6 +9,7 @@ module.exports = {
   app: rootPath('.'),
   dotenv: rootPath('.env'),
   entries: 'src/view/*/index.js',
+  libEntry: 'src/index.js',
   src: rootPath('src'),
   page: rootPath('src/view'),
   public: rootPath('public'),

--- a/package.json
+++ b/package.json
@@ -99,6 +99,9 @@
         "prettier": "^1.10.2"
     },
     "lint-staged": {
-        "**/*.{js,json}": ["prettier", "git add"]
+        "**/*.{js,json}": [
+            "prettier",
+            "git add"
+        ]
     }
 }

--- a/webpack/loaders/style-loader.js
+++ b/webpack/loaders/style-loader.js
@@ -1,14 +1,10 @@
 'use strict'
 
+const path = require('path')
 const autoprefixer = require('autoprefixer')
-const browserslist = require('browserslist')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const config = require('../../config')
 const maraConf = require(config.paths.marauder)
-
-const cssFilename = maraConf.hash
-  ? 'static/css/[name].[contenthash:8].css'
-  : 'static/css/[name].min.css'
 const shouldUseRelativeAssetPaths = maraConf.publicPath === './'
 
 const postcssPlugin = [
@@ -34,6 +30,11 @@ function wrapLoader(options, loaders) {
   if (!options.extract) {
     return ['vue-style-loader'].concat(loaders)
   }
+
+  const assets = options.library ? '' : `${config.assetsDir}/css`
+  const cssFilename = maraConf.hash
+    ? path.join(assets, '[name].[contenthash:8].css')
+    : path.join(assets, '[name].min.css')
 
   // ExtractTextPlugin expects the build output to be flat.
   // (See https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/27)

--- a/webpack/webpack.lib.conf.js
+++ b/webpack/webpack.lib.conf.js
@@ -3,7 +3,7 @@
 const webpack = require('webpack')
 const merge = require('webpack-merge')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
-const marauderDebug = require('sinamfe-marauder-debug')
+// const marauderDebug = require('sinamfe-marauder-debug')
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 
@@ -21,8 +21,8 @@ function getLibraryConf() {
   return pkgName
 }
 
-module.exports = function() {
-  const baseWebpackConfig = require('./webpack.base.conf')()
+module.exports = function(options) {
+  const baseWebpackConfig = require('./webpack.base.conf')('__LIB__')
 
   const webpackConfig = merge(baseWebpackConfig, {
     // 在第一个错误出错时抛出，而不是无视错误
@@ -31,71 +31,72 @@ module.exports = function() {
     devtool: shouldUseSourceMap ? 'source-map' : false,
     output: {
       path: config.paths.lib,
-      filename: 'index.min.js',
+      filename: options.filename,
       library: getLibraryConf(),
-      libraryTarget: 'umd'
+      // https://doc.webpack-china.org/configuration/output/#output-librarytarget
+      libraryTarget: options.format
     },
     plugins: [
       new webpack.DefinePlugin(config.build.env.stringified),
-      new marauderDebug(),
-      // Minify the code.
-      new UglifyJsPlugin({
-        uglifyOptions: {
-          ecma: 8,
-          compress: {
-            warnings: false,
-            // Disabled because of an issue with Uglify breaking seemingly valid code:
-            // https://github.com/facebook/create-react-app/issues/2376
-            // Pending further investigation:
-            // https://github.com/mishoo/UglifyJS2/issues/2011
-            comparisons: false,
-            drop_console: compress.drop_console
+      options.minify &&
+        new UglifyJsPlugin({
+          uglifyOptions: {
+            ecma: 8,
+            compress: {
+              warnings: false,
+              // Disabled because of an issue with Uglify breaking seemingly valid code:
+              // https://github.com/facebook/create-react-app/issues/2376
+              // Pending further investigation:
+              // https://github.com/mishoo/UglifyJS2/issues/2011
+              comparisons: false,
+              drop_console: compress.drop_console
+            },
+            mangle: {
+              safari10: true
+            },
+            output: {
+              comments: false,
+              // Turned on because emoji and regex is not minified properly using default
+              // https://github.com/facebook/create-react-app/issues/2488
+              ascii_only: true
+            }
           },
-          mangle: {
-            safari10: true
-          },
-          output: {
-            comments: false,
-            // Turned on because emoji and regex is not minified properly using default
-            // https://github.com/facebook/create-react-app/issues/2488
-            ascii_only: true
-          }
-        },
-        // Use multi-process parallel running to improve the build speed
-        // Default number of concurrent runs: os.cpus().length - 1
-        parallel: true,
-        // Enable file caching
-        cache: true,
-        sourceMap: shouldUseSourceMap
-      }),
+          // Use multi-process parallel running to improve the build speed
+          // Default number of concurrent runs: os.cpus().length - 1
+          parallel: true,
+          // Enable file caching
+          cache: true,
+          sourceMap: shouldUseSourceMap
+        }),
       new webpack.BannerPlugin({
         banner: banner(), // 其值为字符串，将作为注释存在
         entryOnly: true // 如果值为 true，将只在入口 chunks 文件中添加
       }),
       new ExtractTextPlugin({
-        filename: 'style.css'
+        filename: options.minify ? 'style.min.css' : 'style.css'
       }),
-      new OptimizeCssAssetsPlugin({
-        // cssnano 中自带 autoprefixer，在压缩时会根据配置去除无用前缀
-        // 为保持统一，将其禁用，在 4.0 版本后将会默认禁用
-        // safe: true 禁止计算 z-index
-        cssProcessorOptions: Object.assign(
-          { autoprefixer: false, safe: true },
-          shouldUseSourceMap
-            ? {
-                map: { inline: false }
-              }
-            : {}
-        ),
-        canPrint: false // 不显示通知
-      }),
+      options.minify &&
+        new OptimizeCssAssetsPlugin({
+          // cssnano 中自带 autoprefixer，在压缩时会根据配置去除无用前缀
+          // 为保持统一，将其禁用，在 4.0 版本后将会默认禁用
+          // safe: true 禁止计算 z-index
+          cssProcessorOptions: Object.assign(
+            { autoprefixer: false, safe: true },
+            shouldUseSourceMap
+              ? {
+                  map: { inline: false }
+                }
+              : {}
+          ),
+          canPrint: false // 不显示通知
+        }),
       // Moment.js is an extremely popular library that bundles large locale files
       // by default due to how Webpack interprets its code. This is a practical
       // solution that requires the user to opt into importing specific locales.
       // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
       // You can remove this if you don't use Moment.js:
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/)
-    ]
+    ].filter(Boolean)
   })
 
   return webpackConfig


### PR DESCRIPTION
fix #8 

## 输出

打包后在 lib  文件夹中输出：
- `index.cjs.js`  -- commonJS 模块
- `index.js` --  umd 模块
- `index.min.js` --  压缩后的 umd  模块

如果组件包含样式，同时会在 lib 中输出

- `style.css` -- 原始样式文件（未经 `autoprefixer` 转换）
- `style.min.css` -- 经过 `autoprefixer` 处理及压缩后的样式文件

`pacakge.json` 配置


```
{
  "main": "lib/index.cjs.js",
  ...
}
```

---
## 引用组件

```
import foo from 'foo'
imoort 'foo/lib/style.css'
```